### PR TITLE
Updated app.py to check with VM with key credentials as exports

### DIFF
--- a/gcpdeploy/app.py
+++ b/gcpdeploy/app.py
@@ -2,8 +2,10 @@ from flask import Flask, request, jsonify
 import pickle
 import pandas as pd
 from google.cloud import storage
+from google.oauth2 import service_account
 import os
 import warnings
+import json
 
 # Suppress warnings
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -11,11 +13,9 @@ warnings.filterwarnings("ignore", category=UserWarning)
 # Initialize Flask app
 app = Flask(__name__)
 
-# Set paths for data and Google Cloud credentials
+# Set paths for data
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(PROJECT_DIR, "data", "processed")
-KEY_PATH = os.path.join(PROJECT_DIR, "config", "Key.json")
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = KEY_PATH
 
 # Global variables for model and preprocessors
 model = None
@@ -32,7 +32,6 @@ def load_preprocessing_objects(data_dir):
         with open(f"{data_dir}/{col}_label_encoder.pkl", "rb") as f:
             preprocessors[f"{col}_encoder"] = pickle.load(f)
 
-    # Load scaler and normalizer
     with open(f"{data_dir}/scaler.pkl", "rb") as f:
         preprocessors["scaler"] = pickle.load(f)
 
@@ -43,17 +42,13 @@ def load_preprocessing_objects(data_dir):
 
 def preprocess_input(input_data, preprocessors):
     """Preprocess a single row of input data"""
-    # Create DataFrame with single row
     df = pd.DataFrame([input_data])
 
-    # Process categorical columns one by one
     for col in ["job", "marital", "education", "default", "housing", "loan", "contact", "month"]:
         df[col] = preprocessors[f"{col}_encoder"].transform([input_data[col]])
 
-    # Normalize the entire dataset
     normalized_data = preprocessors["normalizer"].transform(df)
 
-    # Convert to DataFrame with correct column order
     columns = [
         "age", "job", "marital", "education", "default", "balance",
         "housing", "loan", "contact", "day", "month", "duration",
@@ -62,9 +57,18 @@ def preprocess_input(input_data, preprocessors):
     final_df = pd.DataFrame(normalized_data, columns=columns)
     return final_df
 
+def get_gcp_credentials():
+    """Get GCP credentials from environment variable"""
+    creds_json = os.environ.get('GCP_CREDENTIALS')
+    if not creds_json:
+        raise ValueError("GCP_CREDENTIALS environment variable not set")
+    creds_dict = json.loads(creds_json)
+    return service_account.Credentials.from_service_account_info(creds_dict)
+
 def load_model_from_gcp():
     """Load model from GCP bucket"""
-    storage_client = storage.Client()
+    credentials = get_gcp_credentials()
+    storage_client = storage.Client(credentials=credentials)
     bucket = storage_client.bucket("mlopsprojectdatabucketgrp6")
     blob = bucket.blob("models/best_random_forest_model/model.pkl")
     model_bytes = blob.download_as_bytes()
@@ -74,16 +78,9 @@ def load_model_from_gcp():
 def predict():
     """Handle HTTP POST requests for predictions"""
     try:
-        # Get input data from POST request
         input_data = request.json
-
-        # Preprocess input data
         processed_data = preprocess_input(input_data, preprocessors)
-
-        # Make prediction
         prediction = model.predict(processed_data)
-
-        # Return prediction as JSON
         return jsonify({"prediction": int(prediction[0])})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -92,25 +89,16 @@ def predict():
 def health_check():
     """Health check endpoint to verify the service is running."""
     try:
-        # Perform a basic health check (e.g., check if model and preprocessors are loaded)
         if model is None or not preprocessors:
             return jsonify({"status": "unhealthy", "details": "Model or preprocessors not loaded"}), 500
-
-        # Optional: Add more health checks if needed
         return jsonify({"status": "healthy", "details": "Service is running"}), 200
     except Exception as e:
         return jsonify({"status": "unhealthy", "details": str(e)}), 500
 
-# Load preprocessing objects and model at startup
 if __name__ == "__main__":
     try:
-        # Load preprocessing objects
         preprocessors = load_preprocessing_objects(DATA_DIR)
-
-        # Load model from GCP
         model = load_model_from_gcp()
-
-        # Run Flask app
         app.run(host="0.0.0.0", port=8000, debug=True)
     except Exception as e:
         print(f"Error initializing the application: {e}")

--- a/gcpdeploy/setup.sh
+++ b/gcpdeploy/setup.sh
@@ -28,4 +28,21 @@ python3 -m venv env
 # Install requirements (removed --user flag)
 pip install -r requirements.txt
 
+# Set GCP credentials as environment variable
+export GCP_CREDENTIALS='{
+  "type": "service_account",
+  "project_id": "iconic-vine-438222-u6",
+  "private_key_id": "6c69e9e4378e1526f952c267a177be552de33b1a",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDUhdq+mK4mDjP/\nVnMlT8HmeVjv0QiyjPET9bwUNbAGh2u3Xj1Tqn+nhk8II0Q7c88dBZuUfBRkSLdG\nsdgTjoT2tGwMniOvp3+QFFKLE6uEaV96y53YhHtl2kL9Q5RBXs7+OFFr5C3ziw6K\nXtbkcgChz84+6b8nubmGWQQTo4UFKuoldTqCXF8wpXZdIckfBZ5Accrr6wiHmH4m\nsL8nz203hyf+z+SoEgXcs6nhhhu/zfvKy4X10jjmBbQO1ZRdyg9EpJAstiVddKyP\nG2AVJ5iglyC+FhGZ+HxA4huJB0WhR1lqvvxiFlqok8k1XstB8mRiDJpX7n19gs0Z\nH7CDKgorAgMBAAECggEAJAQdOpDAbqWYjUy2zdty5l6pQlcgDLZTAslx2tDwaGLZ\nz+USKpQp9xeNXDkxzouFTYtOPv86K3ahTMNF9aaBBRg1eXvxW0rdFOtEw9oNBq8e\n5b4NHYzyJqQzFx21SdDJ7o5XyhuM6AmoaK3C6EsjrUh80O+nHBHfDZQXW0aqe+Hn\nWuWZBFDJyxQ3zYlzqVvVhE5GtMJQfhrMj4kVOA/9XKr1hfwQHGF2d99qOghqZnt+\nHUwkztHgOiYfzq207ST4k/CdwHkXIqlqrX0voBeRnOFd7r2aiQob/28QfOm6gMSv\nlI11jXMZfAGUfrdP/tfsnfK1hSpnsl37x319i3DOxQKBgQDxQn9vA7FXLEcpTZHw\nJ7wvAS62rznHE0+n417rUWYLjsrUASEAsTzSdaDfnw7zCkI89pRkNinDt0xUFwp/\n2AE8VDX1yHbOwFrYWp9VULEigynnIaNxP8Zt9fGkzxFUraOFoOin9wOp63imJlDy\ny2CzrMl03qTxUxPo1zGWxDbafQKBgQDhgeNSmhEmYFviL4OmVJdy3Nhb+mDaXe5l\n70oE8+v7aFnPUaaXJx61lyJqVw6VradkIj5j2BkNxSMyScqyitWuNjXLAzlR5OwR\nVarjPhdAHGm23Cfql3gu6xv7sDefdcYAc/cUrUGe7jM5RZIcUUbZZ650UVUlBjHx\n+P664xJvxwKBgCbyqUfuvK5qA4Lzdt/iSkr8UeJEH3u37mAYILa0iVjMUIoxNHa8\nJimDu9jeALfTrCXTWNlktRFXggcBQTyqTmjC34MyPZvbCc9rsdVAFZiQvC8ICy65\nMPuHfN8yXoXhEkj8VRLombrQvMV14hOQKahX+J3ZY59h3hD0zJieTIyxAoGBANlJ\nemyhH11HA8IR3lxqrfNzcNZPjvtZ/tghlcTn874vcjodhtOmUiTPF843TEpVJTGK\n/WrfUmS+S4etKq6WsAZJHdQbqyOJ3R1m2l5T+btApWwY/i1A/gDXcgM2bKItrTfK\nhY1a1Bv7kUfiDUNT3VymVqalp9EhAwcQ0QHqwl0JAoGAPjg/rEJLzYt329QOZSsU\nOohcQCjrRwdFYwx40w+wZUy3S84zpzGci+14By+EeRhEiLyyOwmVXOvlc7CB5PQF\nUZ/nADKGH8/4SNRv48r7vKgBm81hBUPui27TysEliT+kC39gKl/q5F8zhdX+ePq0\nUIoA76V6QNfcOdMrr+Gzy2s=\n-----END PRIVATE KEY-----\n",
+  "client_email": "mlopsprojectserviceaccount@iconic-vine-438222-u6.iam.gserviceaccount.com",
+  "client_id": "117500881537772550018",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/mlopsprojectserviceaccount%40iconic-vine-438222-u6.iam.gserviceaccount.com",
+}'
+
+# Add the export command to .bashrc to persist across sessions
+echo "export GCP_CREDENTIALS='$GCP_CREDENTIALS'" >> ~/.bashrc
+
 echo "Setup completed successfully"


### PR DESCRIPTION
Updated app.py to check with VM with key credentials as exports

## Summary by Sourcery

Refactor the application to use GCP credentials from an environment variable instead of a file path, enhancing security and flexibility. Update the setup script to export GCP credentials as an environment variable and ensure it persists across sessions.

Enhancements:
- Refactor app.py to use GCP credentials from an environment variable instead of a file path.

Build:
- Add GCP credentials as an environment variable in setup.sh and persist it across sessions by appending to .bashrc.