### PR TITLE
Fixed a glitch

### DIFF
--- a/gcpdeploy/setup.sh
+++ b/gcpdeploy/setup.sh
@@ -14,7 +14,7 @@ sudo chmod -R 777 /home/bank-marketing-prediction-mlops
 cd /home/bank-marketing-prediction-mlops
 
 # Clone the repository
-git clone --single-branch --branch hashwanth_modeldeployment https://github.com/Saitej0211/Bank_Marketing_Prediction_MLops.git
+git clone https://github.com/Saitej0211/Bank_Marketing_Prediction_MLops.git
 
 # Navigate to the gcpdeploy directory
 cd Bank_Marketing_Prediction_MLops/gcpdeploy


### PR DESCRIPTION
Fixed a glitch

## Summary by Sourcery

Bug Fixes:
- Remove the --single-branch --branch hashwanth_modeldeployment options from the git clone command in the setup script to fix a cloning issue.