### PR TITLE
Updated deployment script

### DIFF
--- a/.github/workflows/CI_CD_gcp_deploy.yml
+++ b/.github/workflows/CI_CD_gcp_deploy.yml
@@ -76,6 +76,11 @@ jobs:
           echo "Copying setup script to VM..."
           gcloud compute scp ./${{ env.STARTUP_SCRIPT_PATH }} term-deposit-prediction-instance:/home/${USER}/startup-script-CI_CD.sh --zone=${{ env.ZONE }}
 
+      - name: Set Execute Permission for Startup Script
+        run: |
+          gcloud compute ssh term-deposit-prediction-instance --zone=${{ env.ZONE }} \
+          --command="chmod +x /home/${USER}/startup-script-CI_CD.sh"
+
       - name: Copy Setup Script to VM
         run: |
           echo "Copying setup script to VM..."

--- a/.github/workflows/Sheela_gcp_deploy.yml
+++ b/.github/workflows/Sheela_gcp_deploy.yml
@@ -71,6 +71,11 @@ jobs:
             --machine-type=e2-micro \
             --subnet=term-deposit-prediction-subnet \
 
+      - name: Copy Startup Script to VM
+        run: |
+          echo "Copying setup script to VM..."
+          gcloud compute scp ./${{ env.STARTUP_SCRIPT_PATH }} term-deposit-prediction-instance:/home/${USER}/startup-script-CI_CD.sh --zone=${{ env.ZONE }}
+
       - name: Copy Setup Script to VM
         run: |
           echo "Copying setup script to VM..."

--- a/.github/workflows/Sheela_gcp_deploy.yml
+++ b/.github/workflows/Sheela_gcp_deploy.yml
@@ -8,7 +8,7 @@ on:
 env:
   CLOUDSDK_CORE_LOG_LEVEL: debug
   PROJECT_ID: iconic-vine-438222-u6
-  ZONE: us-central1-a
+  ZONE: us-east1-a
   SETUP_SCRIPT_PATH: gcpdeploy/setup-CI_CD.sh
   STARTUP_SCRIPT_PATH: gcpdeploy/startup-script-CI_CD.sh
   
@@ -42,7 +42,7 @@ jobs:
           gcloud compute networks subnets create term-deposit-prediction-subnet \
             --project=${{ env.PROJECT_ID }} \
             --network=term-deposit-prediction-vpc \
-            --region=us-central1 \
+            --region=us-east1 \
             --range=10.0.0.0/24
 
       - name: Create Firewall Rules
@@ -112,7 +112,7 @@ jobs:
           gcloud compute instance-templates create term-deposit-prediction-template \
             --machine-type=e2-micro \
             --subnet=term-deposit-prediction-subnet \
-            --region=us-central1 \
+            --region=us-east1 \
             --metadata=startup-script=/home/${USER}/startup-script-CI_CD.sh \
             --tags=http-server,https-server \
             --image=term-deposit-prediction-instance-image \
@@ -126,9 +126,9 @@ jobs:
             --base-instance-name=term-deposit-prediction-instance \
             --size=1 \
             --template=term-deposit-prediction-template \
-            --zone=us-central1-a
+            --zone=us-east1-a
           gcloud compute instance-groups managed set-autoscaling term-deposit-prediction-mig \
-            --zone=us-central1-a \
+            --zone=us-east1-a \
             --max-num-replicas=5 \
             --min-num-replicas=1 \
             --target-cpu-utilization=0.60
@@ -162,7 +162,7 @@ jobs:
 
           gcloud compute backend-services add-backend term-deposit-prediction-backend-service \
             --instance-group=term-deposit-prediction-mig \
-            --instance-group-zone=us-central1-a \
+            --instance-group-zone=us-east1-a \
             --balancing-mode=UTILIZATION \
             --max-utilization=0.8 \
             --capacity-scaler=1 \

--- a/.github/workflows/Sheela_gcp_deploy.yml
+++ b/.github/workflows/Sheela_gcp_deploy.yml
@@ -8,7 +8,7 @@ on:
 env:
   CLOUDSDK_CORE_LOG_LEVEL: debug
   PROJECT_ID: iconic-vine-438222-u6
-  ZONE: us-east1-a
+  ZONE: us-east1-b
   SETUP_SCRIPT_PATH: gcpdeploy/setup-CI_CD.sh
   STARTUP_SCRIPT_PATH: gcpdeploy/startup-script-CI_CD.sh
   
@@ -126,9 +126,9 @@ jobs:
             --base-instance-name=term-deposit-prediction-instance \
             --size=1 \
             --template=term-deposit-prediction-template \
-            --zone=us-east1-a
+            --zone=us-east1-b
           gcloud compute instance-groups managed set-autoscaling term-deposit-prediction-mig \
-            --zone=us-east1-a \
+            --zone=us-east1-b \
             --max-num-replicas=5 \
             --min-num-replicas=1 \
             --target-cpu-utilization=0.60
@@ -162,7 +162,7 @@ jobs:
 
           gcloud compute backend-services add-backend term-deposit-prediction-backend-service \
             --instance-group=term-deposit-prediction-mig \
-            --instance-group-zone=us-east1-a \
+            --instance-group-zone=us-east1-b \
             --balancing-mode=UTILIZATION \
             --max-utilization=0.8 \
             --capacity-scaler=1 \

--- a/.github/workflows/Sheela_gcp_deploy.yml
+++ b/.github/workflows/Sheela_gcp_deploy.yml
@@ -3,7 +3,7 @@ name: GCP Deploy CI/CD
 on:
   push:
     branches:
-      - Sheela-deployment  # Test 8
+      - Sheela-deployment  # Test 9
 
 env:
   CLOUDSDK_CORE_LOG_LEVEL: debug

--- a/gcpdeploy/setup-CI_CD.sh
+++ b/gcpdeploy/setup-CI_CD.sh
@@ -36,8 +36,4 @@ fi
 # Install requirements
 pip install -r requirements.txt
 
-# Copy the startup script to the VM's home directory
-cp /home/bank-marketing-prediction-mlops/Bank_Marketing_Prediction_MLops/gcpdeploy/startup-script-CI_CD.sh /home/${USER}/startup-script-CI_CD.sh
-chmod +x /home/${USER}/startup-script-CI_CD.sh
-
 echo "Setup completed successfully"


### PR DESCRIPTION
## Summary by Sourcery

Update the GCP deployment script to change the region and zone to 'us-east1' and add steps for handling the startup script on the VM.

Deployment:
- Update the deployment script to change the GCP region and zone from 'us-central1' to 'us-east1'.
- Add steps to copy and set execute permissions for the startup script on the VM during deployment.